### PR TITLE
Allow use of %uid variable in base string

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ then, add LDAP settings in Meteor.settings (using METEOR_SETTINGS env or --setti
   },
 ```
 
-* **url** and **base** are mandatory
+* **url** is mandatory.
+* **base** is mandatory. All instances of %uid will be replaced.
 * ldapjs connexion parameters **timeout** and **connectTimeout** can be used
 * to bind anonymous, set **bindDn** and **bindSecret** to empty string
 * **filter** allow you to specify the search filter. all instances of %uid will be replaced. Default is "(uid=%uid)"

--- a/ldap_profile_server.js
+++ b/ldap_profile_server.js
@@ -224,6 +224,7 @@
     var future = new Future();
 
     var base = this.opts.base;
+    base = base.replace(/%uid/g, uid);
 
     // set filter
     var filter = this.opts.filter || "(uid=%uid)";


### PR DESCRIPTION
In my particular application, uid was only present in the dn attribute of the entry itself, meaning I had to insert uid into the base string in order to find the entry I needed. This commit performs the same replacement of %uid on the base argument as it already did on filter. 
